### PR TITLE
Bump excon to 0.9.0 to avoid deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source :rubygems
 
 gem "faraday", "~> 0.5.7"
 
-gem "excon", "~> 0.5.6"
+gem "excon", "~> 0.9.0"
 gem "yajl-ruby", "~> 0.8.1", :require => "yajl"
 
 gem "activesupport", "~> 3.0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     activesupport (3.0.4)
     addressable (2.2.4)
     diff-lcs (1.1.2)
-    excon (0.5.6)
+    excon (0.9.0)
     faraday (0.5.7)
       addressable (~> 2.2.4)
       multipart-post (~> 1.1.0)

--- a/pingdom-client.gemspec
+++ b/pingdom-client.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
     
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency("faraday",       ["~> 0.5.7"])
-      s.add_runtime_dependency("excon",         ["~> 0.5.6"])
+      s.add_runtime_dependency("excon",         ["~> 0.9.0"])
       s.add_runtime_dependency("yajl-ruby",     ["~> 0.8.1"])
       s.add_runtime_dependency("activesupport", ["~> 3.0.4"])
       s.add_runtime_dependency("i18n",          ["~> 0.5.0"])
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency("rspec",   ["= 2.1.0"])
     else
       s.add_dependency("faraday",       ["~> 0.5.7"])
-      s.add_dependency("excon",         ["~> 0.5.6"])
+      s.add_dependency("excon",         ["~> 0.9.0"])
       s.add_dependency("yajl-ruby",     ["~> 0.8.1"])
       s.add_dependency("activesupport", ["~> 3.0.4"])
       s.add_dependency("i18n",          ["~> 0.5.0"])
@@ -66,7 +66,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency("faraday",       ["~> 0.5.7"])
-    s.add_dependency("excon",         ["~> 0.5.6"])
+    s.add_dependency("excon",         ["~> 0.9.0"])
     s.add_dependency("yajl-ruby",     ["~> 0.8.1"])
     s.add_dependency("activesupport", ["~> 3.0.4"])
     s.add_dependency("i18n",          ["~> 0.5.0"])


### PR DESCRIPTION
Feel free to bump it the next 30 versions, but this gets it passed the
Config vs. RBConfig warnings
